### PR TITLE
Improved setuptools support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,4 +54,4 @@ toml =
 
 [options.entry_points]
 setuptools.finalize_distribution_options =
-    read_version = read_version:setuptools_finalizer
+    read_version @ {"only": "toml"} = read_version:setuptools_finalizer


### PR DESCRIPTION
https://github.com/pypa/setuptools/pull/2036 and https://github.com/pypa/setuptools/pull/2034

They are not merged yet, but feel free to merge this PR once they are merged. Also removed `tool.` prefix.